### PR TITLE
Add Testcontainers-based integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,26 @@
             <artifactId>lombok</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mongodb</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>redis</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/com/example/demo/config/RedisConfig.java
+++ b/src/main/java/com/example/demo/config/RedisConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisClusterConfiguration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
@@ -16,13 +17,23 @@ import java.util.List;
 @Configuration
 public class RedisConfig {
 
-    @Value("${spring.data.redis.cluster.nodes}")
+    @Value("${spring.data.redis.cluster.nodes:}")
     private List<String> clusterNodes;
+
+    @Value("${spring.data.redis.host:localhost}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port:6379}")
+    private int redisPort;
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        RedisClusterConfiguration clusterConfiguration = new RedisClusterConfiguration(clusterNodes);
-        return new LettuceConnectionFactory(clusterConfiguration);
+        if (clusterNodes != null && !clusterNodes.isEmpty()) {
+            RedisClusterConfiguration clusterConfiguration = new RedisClusterConfiguration(clusterNodes);
+            return new LettuceConnectionFactory(clusterConfiguration);
+        }
+        RedisStandaloneConfiguration standaloneConfiguration = new RedisStandaloneConfiguration(redisHost, redisPort);
+        return new LettuceConnectionFactory(standaloneConfiguration);
     }
 
     @Bean

--- a/src/test/java/com/example/demo/service/ItemServiceIntegrationTest.java
+++ b/src/test/java/com/example/demo/service/ItemServiceIntegrationTest.java
@@ -1,0 +1,63 @@
+package com.example.demo.service;
+
+import com.example.demo.model.Item;
+import com.example.demo.repository.ItemRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Testcontainers
+@SpringBootTest
+public class ItemServiceIntegrationTest {
+
+    @Container
+    static MongoDBContainer mongo = new MongoDBContainer("mongo:7.0.9");
+
+    @Container
+    static GenericContainer<?> redis = new GenericContainer<>("redis:7-alpine").withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.mongodb.uri", mongo::getReplicaSetUrl);
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379));
+    }
+
+    @Autowired
+    private ItemService service;
+
+    @Autowired
+    private ItemRepository repository;
+
+    @Test
+    void shouldCreateAndRetrieveItem() {
+        Item item = new Item(null, "test", "desc");
+        Item saved = service.create(item);
+
+        Optional<Item> found = service.get(saved.getId());
+        assertTrue(found.isPresent());
+        assertEquals("test", found.get().getName());
+    }
+
+    @Test
+    void shouldReturnItemFromCacheAfterDeletionFromDatabase() {
+        Item item = new Item(null, "cache", "desc");
+        Item saved = service.create(item);
+
+        repository.deleteById(saved.getId());
+
+        Optional<Item> fromCache = service.get(saved.getId());
+        assertTrue(fromCache.isPresent());
+        assertEquals("cache", fromCache.get().getName());
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+external:
+  service:
+    url: http://localhost:8081


### PR DESCRIPTION
## Summary
- support standalone Redis in configuration
- add Testcontainers and spring-boot-starter-test dependencies
- cover ItemService with MongoDB and Redis integration tests

## Testing
- `mvn test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to central)*

------
https://chatgpt.com/codex/tasks/task_e_68bc11806b6c8329aab46b582f72452c